### PR TITLE
Open all diffs in external editor

### DIFF
--- a/FileDiffs.sublime-settings
+++ b/FileDiffs.sublime-settings
@@ -3,10 +3,11 @@
 	// just uncomment one of the examples
 	// or write your own command
 
-  // opendiff (FileMerge)
-  //"cmd": ["opendiff", "$file1", "$file2"]
+ 	// opendiff (FileMerge)
+ 	// "cmd": ["opendiff", "$file1", "$file2"]
 
 	// ksdiff (Kaleidoscope)
-	//"cmd": ["ksdiff", "$file1", "$file2"]
+	// "cmd": ["ksdiff", "$file1", "$file2"]
 
+	// "open_in_sublime": false
 }


### PR DESCRIPTION
Hi,

I fall in love with your plugin. The only thing I had missed was opening all diffs (clipboard, unsaved, ...) in external editor. It wasn't possible because external editor can work only with existing files. It worked with tabs and project files only.

What have I done: I save tmp file and than it is possible to open all diffs in external editor. I have tested this on Mac Os.

It was also a little bit annoying that the plugin open the file in external editor and new tab in Sublime. So I added option to turn it off. Maybe it will be practical to turn it off by default if the opening in external editor is succesfull.

Thanks for your plugin,

Jiri
