### PR TITLE
Bug fix for unnamed view

### DIFF
--- a/file_diffs.py
+++ b/file_diffs.py
@@ -311,7 +311,7 @@ class FileDiffSavedCommand(FileDiffCommand):
             **kwargs)
 
     def is_visible(self):
-        return self.view.file_name() and self.view.is_dirty()
+        return bool(self.view.file_name()) and self.view.is_dirty()
 
 
 class FileDiffFileCommand(FileDiffCommand):


### PR DESCRIPTION
I was seeing a lot of these errors in ST3:

```
Traceback (most recent call last):
  File "/opt/sublime_text_3_build_3065_x64/sublime_plugin.py", line 472, in is_visible_
    raise ValueError("is_visible must return a bool", self)
ValueError: ('is_visible must return a bool', <FileDiffs.file_diffs.FileDiffSavedCommand object at 0x7f5632ffc9d0>)
```

`file_name()` returns `None` for a new view that hasn't been saved yet and has no name, and apparently Python won't coerce that to boolean, so the return value type is wrong. Either wrapping in `bool( ... )` or using `self.view.file_name() is not None` both worked for me.
