### PR TITLE
Don't use HTML popup for "No Difference" message

### DIFF
--- a/file_diffs.py
+++ b/file_diffs.py
@@ -99,10 +99,8 @@ class FileDiffCommand(sublime_plugin.TextCommand):
         diffs = list(difflib.unified_diff(from_content, to_content, from_file, to_file))
 
         if not diffs:
-            if sublime.version() < '3000':
-                sublime.status_message('No Difference')
-            else:
-                self.view.show_popup('<span style="font-size: 10pt">No Difference</span>')
+            sublime.status_message('No Difference')
+
         else:
             external_command = external_diff_tool or self.get_setting('cmd')
             open_in_sublime = self.get_setting('open_in_sublime', not external_command)


### PR DESCRIPTION
It causes bad UX when the cursor is not visible in the view i.e. the view is
scrolled to the opposite direction. In that case, the user doesn't notice the
popup because it appears next to the unvisible cursor.