### PR TITLE
update Main.sublime-menu to use edit_settings for side-by-side settings

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -15,8 +15,14 @@
                         "caption": "FileDiffs",
                         "children":
                         [
-                            { "command": "open_file", "args": {"file": "${packages}/FileDiffs/FileDiffs.sublime-settings"}, "caption": "Settings – Default" },
-                            { "command": "open_file", "args": {"file": "${packages}/User/FileDiffs.sublime-settings"}, "caption": "Settings – User" },
+                            {
+                                "command": "edit_settings",
+                                "args": {
+                                    "base_file": "${packages}/FileDiffs/FileDiffs.sublime-settings",
+                                    "default": "{\n$0\n}\n"
+                                },
+                                "caption": "Settings"
+                            },
                             { "caption": "-" }
                         ]
                     }


### PR DESCRIPTION
Uses `edit_settings` so that the Main menu opens settings side-by-side when editing.

- fixes https://github.com/colinta/SublimeFileDiffs/issues/91

Note: I haven't tested this locally, but the change was pretty small so probably should be fine. Worth a double check before publishing.

(See the linked issue for 'prior art' references and docs)